### PR TITLE
feat: create dmarc stack INFRA-80

### DIFF
--- a/dmarc/docker-compose.yml
+++ b/dmarc/docker-compose.yml
@@ -4,10 +4,8 @@ services:
     hostname: dmarc-report
     container_name: dmarc-report
     depends_on:
-      # FIXME: Swarm doesn't support this syntax yet
-      # db:
-      #   condition: service_healthy
-      - db
+      db:
+        condition: service_healthy
     environment:
       - "REPORT_DB_TYPE=pgsql"
       - "REPORT_DB_PORT=5432"

--- a/dmarc/docker-compose.yml
+++ b/dmarc/docker-compose.yml
@@ -4,8 +4,10 @@ services:
     hostname: dmarc-report
     container_name: dmarc-report
     depends_on:
-      db:
-        condition: service_healthy
+      # FIXME: Swarm doesn't support this syntax yet
+      # db:
+      #   condition: service_healthy
+      - db
     environment:
       - "REPORT_DB_TYPE=pgsql"
       - "REPORT_DB_PORT=5432"

--- a/dmarc/docker-compose.yml
+++ b/dmarc/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - "PARSER_IMAP_READ_FOLDER=Inbox"
       - "PARSER_IMAP_MOVE_FOLDER=${IMAP_MOVE_FOLDER:-processed}"
       - "PARSER_IMAP_MOVE_FOLDER_ERR=${IMAP_MOVE_FOLDER_ERR:-error}"
+      - "PARSER_IMAP_SSL=1"
+      - "PARSER_IMAP_TLS=0"
     labels:
       caddy: dmarc-report.home.mliebman.com
       caddy.reverse_proxy: "{{upstreams 80}}"

--- a/dmarc/docker-compose.yml
+++ b/dmarc/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       - "REPORT_DB_TYPE=pgsql"
       - "REPORT_DB_PORT=5432"
+      - "REPORT_DB_HOST=dmarc-db"
       - "REPORT_DB_NAME=dmarc_report"
       - "REPORT_DB_USER=dmarc_report"
       - "REPORT_DB_PASS=${DMARC_DB_PASSWORD}"
@@ -29,6 +30,8 @@ services:
 
   db:
     image: postgres:17.2-alpine3.21
+    hostname: dmarc-db
+    container_name: dmarc-db
     environment:
       - "POSTGRES_DB=dmarc_report"
       - "POSTGRES_USER=dmarc_report"

--- a/dmarc/docker-compose.yml
+++ b/dmarc/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  dmarc-report:
+    image: "gutmensch/dmarc-report:1.4.5"
+    hostname: dmarc-report
+    container_name: dmarc-report
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - "REPORT_DB_TYPE=pgsql"
+      - "REPORT_DB_PORT=5432"
+      - "REPORT_DB_NAME=dmarc_report"
+      - "REPORT_DB_USER=dmarc_report"
+      - "REPORT_DB_PASS=${DMARC_DB_PASSWORD}"
+      - "PARSER_IMAP_SERVER=${IMAP_SERVER}"
+      - "PARSER_IMAP_PORT=${IMAP_PORT:-993}"
+      - "PARSER_IMAP_USER=${DMARC_EMAIL}"
+      - "PARSER_IMAP_PASS=${DMARC_PASSWORD}"
+      - "PARSER_IMAP_READ_FOLDER=Inbox"
+      - "PARSER_IMAP_MOVE_FOLDER=${IMAP_MOVE_FOLDER:-processed}"
+      - "PARSER_IMAP_MOVE_FOLDER_ERR=${IMAP_MOVE_FOLDER_ERR:-error}"
+    labels:
+      caddy: dmarc-report.home.mliebman.com
+      caddy.reverse_proxy: "{{upstreams 80}}"
+      caddy.tls: internal
+
+  db:
+    image: postgres:17.2-alpine3.21
+    environment:
+      - "POSTGRES_DB=dmarc_report"
+      - "POSTGRES_USER=dmarc_report"
+      - "POSTGRES_PASSWORD=${DMARC_DB_PASSWORD}"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dmarc_report"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
+networks:
+  internal:
+  caddy:
+    external: true
+
+volumes:
+  db-data:

--- a/dmarc/docker-compose.yml
+++ b/dmarc/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       caddy: dmarc-report.home.mliebman.com
       caddy.reverse_proxy: "{{upstreams 80}}"
       caddy.tls: internal
+    networks:
+      - internal
+      - caddy
 
   db:
     image: postgres:17.2-alpine3.21
@@ -39,6 +42,8 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
+    networks:
+      - internal
 
 networks:
   internal:

--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -134,3 +134,8 @@
             type: uptimerobot
             url: https://api.uptimerobot.com
             key: "{{HOMEPAGE_VAR_UPTIME_ROBOT_RO_KEY}}"
+    - DMARC Report:
+        href: https://dmarc-report.home.mliebman.com/
+        description: Email delivery reports
+        icon: mdi-package-check
+        siteMonitor: https://dmarc-report.home.mliebman.com


### PR DESCRIPTION
NOTE: This stack must run in compose, not swarm because the dependency style is not supported by swarm yet.